### PR TITLE
Add big endian encoding/decoding helper fn for ID

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,6 +16,15 @@ func BenchmarkNext(b *testing.B) {
 	}
 }
 
+func BenchmarkNextWithEpoch(b *testing.B) {
+	b.ReportAllocs()
+
+	mf, _ := monoflake.New(0, monoflake.WithEpoch(time.Now()))
+	for n := 0; n < b.N; n++ {
+		_ = mf.Next()
+	}
+}
+
 func BenchmarkNextCompare(b *testing.B) {
 	b.ReportAllocs()
 
@@ -41,11 +50,47 @@ func BenchmarkNextBase62(b *testing.B) {
 	}
 }
 
+func BenchmarkNextBase62WithEpoch(b *testing.B) {
+	b.ReportAllocs()
+
+	mf, _ := monoflake.New(0, monoflake.WithEpoch(time.Now()))
+	for n := 0; n < b.N; n++ {
+		_ = mf.Next().String()
+	}
+}
+
 func BenchmarkNextBytes(b *testing.B) {
+	b.ReportAllocs()
+
+	mf, _ := monoflake.New(0)
+	for n := 0; n < b.N; n++ {
+		_ = mf.Next().Bytes()
+	}
+}
+
+func BenchmarkNextBytesWithEpoch(b *testing.B) {
 	b.ReportAllocs()
 
 	mf, _ := monoflake.New(0, monoflake.WithEpoch(time.Now()))
 	for n := 0; n < b.N; n++ {
 		_ = mf.Next().Bytes()
+	}
+}
+
+func BenchmarkNextBigEndianBytes(b *testing.B) {
+	b.ReportAllocs()
+
+	mf, _ := monoflake.New(0)
+	for n := 0; n < b.N; n++ {
+		_ = mf.Next().BigEndianBytes()
+	}
+}
+
+func BenchmarkNextBigEndianBytesWithEpoch(b *testing.B) {
+	b.ReportAllocs()
+
+	mf, _ := monoflake.New(0, monoflake.WithEpoch(time.Now()))
+	for n := 0; n < b.N; n++ {
+		_ = mf.Next().BigEndianBytes()
 	}
 }

--- a/id_test.go
+++ b/id_test.go
@@ -232,6 +232,7 @@ func TestFromBase62RuneToInt64(t *testing.T) {
 	}
 
 	got = fromBase62RuneToInt64('!')
+	want = 0
 	if got != want {
 		t.Errorf(msg, string('!'), want, got)
 	}


### PR DESCRIPTION
Add big endian encoding/decoding helper fn for ID to reduce size on bytes conversion.

Return -1 on overload int64

Enhance benchmarks where previous benchmarks was hiding the default epoch, the new ones reports with both provided epoch and default.